### PR TITLE
Add test_mode parameter to trackers and update tests for initialization

### DIFF
--- a/physiocore/src/physiocore/any_prone_straight_leg_raise.py
+++ b/physiocore/src/physiocore/any_prone_straight_leg_raise.py
@@ -85,7 +85,7 @@ class PoseTracker:
         self.r_raise_pose = False
 
 class AnyProneSLRTracker:
-    def __init__(self, config_path=None):
+    def __init__(self, test_mode=False, config_path=None):
         flag_config_obj = modern_flags.parse_config()
         self.reps = flag_config_obj.reps
         self.debug = flag_config_obj.debug
@@ -99,8 +99,8 @@ class AnyProneSLRTracker:
 
         self.pose_tracker = PoseTracker(self.config, self.lenient_mode)
         self.smoother = LandmarkSmoother()
-        self.l_timer = AdaptiveHoldTimer(initial_hold_secs=self.hold_secs)
-        self.r_timer = AdaptiveHoldTimer(initial_hold_secs=self.hold_secs)
+        self.l_timer = AdaptiveHoldTimer(initial_hold_secs=self.hold_secs, test_mode = test_mode)
+        self.r_timer = AdaptiveHoldTimer(initial_hold_secs=self.hold_secs, test_mode = test_mode)
         self.count = 0
         self.cap = None
         self.output = None

--- a/physiocore/src/physiocore/any_straight_leg_raise.py
+++ b/physiocore/src/physiocore/any_straight_leg_raise.py
@@ -82,7 +82,7 @@ class PoseTracker:
         self.l_raise_pose = self.r_raise_pose = False
 
 class AnySLRTracker:
-    def __init__(self, config_path=None):
+    def __init__(self, test_mode=False, config_path=None):
         flag_config_obj = modern_flags.parse_config()
         self.reps = flag_config_obj.reps
         self.debug = flag_config_obj.debug
@@ -98,8 +98,8 @@ class AnySLRTracker:
             self.hold_secs = 8.0 * self.hold_secs / 30.0
 
         self.pose_tracker = PoseTracker(self.config, self.lenient_mode)
-        self.l_timer = AdaptiveHoldTimer(initial_hold_secs=self.hold_secs)
-        self.r_timer = AdaptiveHoldTimer(initial_hold_secs=self.hold_secs)
+        self.l_timer = AdaptiveHoldTimer(initial_hold_secs=self.hold_secs, test_mode = test_mode)
+        self.r_timer = AdaptiveHoldTimer(initial_hold_secs=self.hold_secs, test_mode = test_mode)
         self.count = 0
         self.cap = None
         self.output = None

--- a/physiocore/src/physiocore/bridging.py
+++ b/physiocore/src/physiocore/bridging.py
@@ -69,7 +69,7 @@ class PoseTracker:
         self.raise_pose = False
 
 class BridgingTracker:
-    def __init__(self, config_path=None):
+    def __init__(self, test_mode=False, config_path=None):
         flag_config_obj = modern_flags.parse_config()
         self.reps = flag_config_obj.reps
         self.debug = flag_config_obj.debug
@@ -82,7 +82,7 @@ class BridgingTracker:
         self.hold_secs = self.config.get("HOLD_SECS", 5)
 
         self.pose_tracker = PoseTracker(self.config, self.lenient_mode)
-        self.timer = AdaptiveHoldTimer(initial_hold_secs=self.hold_secs)
+        self.timer = AdaptiveHoldTimer(initial_hold_secs=self.hold_secs, test_mode = test_mode)
         self.count = 0
         self.cap = None
         self.output = None

--- a/physiocore/src/physiocore/neck_rotation.py
+++ b/physiocore/src/physiocore/neck_rotation.py
@@ -34,7 +34,7 @@ class PoseTracker:
         self.state = "center"
 
 class NeckRotationTracker:
-    def __init__(self, config_path=None):
+    def __init__(self, test_mode=False, config_path=None):
         flag_config_obj = modern_flags.parse_config()
         self.reps = flag_config_obj.reps
         self.debug = flag_config_obj.debug

--- a/physiocore/tests/test_bridging.py
+++ b/physiocore/tests/test_bridging.py
@@ -5,11 +5,13 @@ from physiocore.bridging import BridgingTracker
 class TestBridgingTracker(unittest.TestCase):
 
     def test_bridging_video(self):
-        tracker = BridgingTracker()
+        tracker = BridgingTracker(test_mode=True)
         
         # Override HOLD_SECS
         # TODO: Investigate why override needed with display off mode
-        tracker.hold_secs = 0.1
+        display=False
+        hold_secs = 0.5 if display else 0.1
+        tracker.set_hold_secs(hold_secs)
         
         # Get the path to the video file
         video_path = os.path.join(os.path.dirname(__file__), 'bridging.mp4')

--- a/physiocore/tests/test_neck_rotation.py
+++ b/physiocore/tests/test_neck_rotation.py
@@ -6,7 +6,7 @@ from physiocore.neck_rotation import NeckRotationTracker
 class TestNeckRotationTracker(unittest.TestCase):
 
     def test_tracker_initialization(self):
-        tracker = NeckRotationTracker()
+        tracker = NeckRotationTracker(test_mode=True)
         video_path = os.path.join(os.path.dirname(__file__), 'neck-rotation-test.mp4')
         
         # Process the video without displaying GUI

--- a/physiocore/tests/test_prone.py
+++ b/physiocore/tests/test_prone.py
@@ -5,10 +5,12 @@ from physiocore.any_prone_straight_leg_raise import AnyProneSLRTracker
 class TestAnyProneSLRTracker(unittest.TestCase):
 
     def test_any_prone_video(self):
-        tracker = AnyProneSLRTracker()
+        tracker = AnyProneSLRTracker(test_mode=True)
         
         # Override HOLD_SECS
-        # tracker.hold_secs = 1.0
+        display=False
+        hold_secs = 1 if display else 0.1
+        tracker.set_hold_secs(hold_secs)
         
         # Get the path to the video file
         video_path = os.path.join(os.path.dirname(__file__), 'prone-mini-test.mp4')

--- a/physiocore/tests/test_prone_hold.py
+++ b/physiocore/tests/test_prone_hold.py
@@ -6,8 +6,10 @@ class TestAnyProneSLRTracker(unittest.TestCase):
     def test_any_prone_long_hold_video(self):
         tracker = AnyProneSLRTracker()
         
-        # Override HOLD_SECS
-        tracker.hold_secs = 8.0
+        # Override HOLD_SECS for testing
+        display=False
+        hold_secs = 10 if display else 8.0
+        tracker.set_hold_secs(hold_secs)
         
         # Get the path to the video file
         video_path = os.path.join(os.path.dirname(__file__), 'prone-long-hold-2.mp4')

--- a/physiocore/tests/test_prone_hold2.py
+++ b/physiocore/tests/test_prone_hold2.py
@@ -4,16 +4,18 @@ from physiocore.any_prone_straight_leg_raise import AnyProneSLRTracker
 
 class TestAnyProneSLRTracker(unittest.TestCase):
     def test_any_prone_long_hold_video(self):
-        tracker = AnyProneSLRTracker()
+        tracker = AnyProneSLRTracker(test_mode=True)
         
         # Override HOLD_SECS
-        tracker.hold_secs = 4.0
+        display=False
+        hold_secs = 6 if display else 4
+        tracker.set_hold_secs(hold_secs)
         
         # Get the path to the video file
         video_path = os.path.join(os.path.dirname(__file__), 'prone-SLR-hold-4sec-pankaj1.mp4')
         
         # Process the video without displaying GUI
-        count = tracker.process_video(video_path=video_path, display=True)
+        count = tracker.process_video(video_path=video_path, display=False)
         self.assertEqual(count, 6)
 
 if __name__ == '__main__':

--- a/physiocore/tests/test_prone_hold3.py
+++ b/physiocore/tests/test_prone_hold3.py
@@ -4,17 +4,19 @@ from physiocore.any_prone_straight_leg_raise import AnyProneSLRTracker
 
 class TestAnyProneSLRTracker(unittest.TestCase):
     def test_any_prone_long_hold_video(self):
-        tracker = AnyProneSLRTracker()
+        tracker = AnyProneSLRTracker(test_mode=True)
         
         # Override HOLD_SECS
-        tracker.hold_secs = 9.0
+        display=False
+        hold_secs = 12 if display else 6
+        tracker.set_hold_secs(hold_secs)
         
         # Get the path to the video file
         # The model fluctuates and the counter resets, this test is failing.
         video_path = os.path.join(os.path.dirname(__file__), 'prone-long-hold.mp4')
         
         # Process the video without displaying GUI
-        count = tracker.process_video(video_path=video_path, display=True)
+        count = tracker.process_video(video_path=video_path, display=False)
         self.assertEqual(count, 1)
 
 if __name__ == '__main__':

--- a/physiocore/tests/test_slr.py
+++ b/physiocore/tests/test_slr.py
@@ -5,12 +5,13 @@ from physiocore.any_straight_leg_raise import AnySLRTracker
 class TestAnySLRTracker(unittest.TestCase):
 
     def test_slr_video(self):
-        tracker = AnySLRTracker()
+        tracker = AnySLRTracker(test_mode=True)
         tracker.debug = True
         
         # Override HOLD_SECS for testing
         display = False
-        tracker.hold_secs = 1.0 if display else 0.5
+        hold_secs = 1 if display else 0.5
+        tracker.set_hold_secs(hold_secs)
         
         # Get the path to the video file
         video_path = os.path.join(os.path.dirname(__file__), 'slr-mini.mp4')


### PR DESCRIPTION
This pull request introduces `test_mode` parameter to several tracker classes in the `physiocore` package and updates corresponding unit tests to utilize this mode for more consistent and configurable test runs. 

### Tracker class enhancements
* Added `test_mode` parameter to the constructors of `AnyProneSLRTracker`, `AnySLRTracker`, `BridgingTracker`, and `NeckRotationTracker` classes.

### Test suite improvements
* Modified all relevant test cases to instantiate tracker objects with `test_mode=True`, ensuring consistent test behavior. 
* Updated tests to set hold times via `set_hold_secs()` instead of direct assignment, and to process videos with `display=False` for headless testing. 